### PR TITLE
reformatted fastlane fulldesc to render properly

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,17 +1,17 @@
-  PlugBrain is an app that encourages regular breaks from distracting apps by blocking access at scheduled intervals.
-  To regain access, you’ll need to solve a math challenge that adjusts in difficulty:
-  the more frequently you use the apps, the harder the challenges become,
-  but the longer you stay away, the easier they get.
+PlugBrain is an app that encourages regular breaks from distracting apps by blocking access at scheduled intervals.
+To regain access, you’ll need to solve a math challenge that adjusts in difficulty: the more frequently you use the apps, the harder the challenges become, but the longer you stay away, the easier they get.
 
-  **Features**
-  - No ads
-  - No internet required
-  - Blocks distracting apps
-  - Unblock apps by solving math challenges
-  - Difficulty increases with frequent use, decreases with focus
+**Features**
 
-  **How to use**
-  - Grant all required permissions
-  - Select distracting apps
-  - Choose your focus interval
-  - Stay focused ;)
+- No ads
+- No internet required
+- Blocks distracting apps
+- Unblock apps by solving math challenges
+- Difficulty increases with frequent use, decreases with focus
+
+**How to use**
+
+- Grant all required permissions
+- Select distracting apps
+- Choose your focus interval
+- Stay focused ;)


### PR DESCRIPTION
These changes allow to render the description as Markdown, which looks much better then:

<img width="929" height="602" alt="image" src="https://github.com/user-attachments/assets/09855add-78cf-4ac4-a80f-9cced59771b2" />

This screenshot is from the [IzzyOnDroid repo](https://apt.izzysoft.de/fdroid); PlugBrain is available at https://apt.izzysoft.de/fdroid/index/apk/app.plugbrain.android since yesterday, be welcome to [pick a badge](https://gitlab.com/IzzyOnDroid/repo/#if-my-app-is-available-here-do-you-have-a-badge-i-can-use-to-link-to-it) to link there e.g. from your Readme – and also a shield to show your app's RB status:

[<img src="https://shields.rbtlog.dev/simple/app.plugbrain.android" alt="RB shield">](https://shields.rbtlog.dev/app.plugbrain.android)

`[<img src="https://shields.rbtlog.dev/simple/app.plugbrain.android" alt="RB shield">](https://shields.rbtlog.dev/app.plugbrain.android)`