### PR TITLE
Lock ChallengeActivity to portrait orientation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         <activity
             android:name=".ui.challenges.ChallengeActivity"
             android:resizeableActivity="false"
+            android:screenOrientation="portrait"
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.MathlockApp" />


### PR DESCRIPTION
## Summary
- Adds `android:screenOrientation="portrait"` to `ChallengeActivity` in the manifest
- Prevents screen rotation from recreating the activity, which was resetting the challenge and its difficulty

This is the approach @msbelaid suggested in https://github.com/msbelaid/PlugBrain/issues/87#issuecomment-3478389037 as the best solution for now. Portrait mode also makes sense UX-wise since the number pad input works best in that orientation.

Fixes #87